### PR TITLE
Package.swift: Added file to support Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "KGNAutoLayout",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KGNAutoLayout",
+            targets: ["KGNAutoLayout"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "KGNAutoLayout",
+            dependencies: [],
+            path: "Source"),
+        .testTarget(
+            name: "KGNAutoLayoutTests",
+            dependencies: ["KGNAutoLayout"],
+            path: "Tests"),
+    ]
+)


### PR DESCRIPTION
This adds support for Swift Package Manager by creating a Package.swift file with customized paths to avoid needing to change the project's structure.

It seems that SPM won't properly detect the existence of the added file unless a new version of the library is released (1.8.2)